### PR TITLE
Improve responsive images

### DIFF
--- a/src/app/(Ebowwa_Branding)/dev/img-convert/page.tsx
+++ b/src/app/(Ebowwa_Branding)/dev/img-convert/page.tsx
@@ -60,7 +60,11 @@ export default function Page() {
           {imageFile.status === 'pending' && <p>Converting {imageFile.format} to WebP...</p>}
           {imageFile.status === 'verifying' && <p>Verifying WebP conversion...</p>}
           {imageFile.status === 'converted' && (
-            <img src={imageFile.webpUrl!} alt={`Converted Image ${index}`} />
+            <img
+              src={imageFile.webpUrl!}
+              alt={`Converted Image ${index}`}
+              style={{ maxWidth: '100%', height: 'auto' }}
+            />
           )}
           {imageFile.status === 'error' && (
             <p>Error converting {imageFile.format} to WebP: {imageFile.errorMessage}</p>

--- a/src/app/(examples)/screenshot/page.tsx
+++ b/src/app/(examples)/screenshot/page.tsx
@@ -15,7 +15,7 @@ const MyPage: React.FC = () => {
             <button onClick={takeScreenshot}>Take Screenshot</button>
             {screenshot && (
                 <div>
-                    <img src={screenshot} alt="Screenshot" style={{ maxWidth: '100%' }} />
+                    <img src={screenshot} alt="Screenshot" style={{ maxWidth: '100%', height: 'auto' }} />
                     {isDownloadable && (
                         <button onClick={downloadScreenshot}>Download Screenshot</button>
                     )}

--- a/src/app/(landing)/blog/page.tsx
+++ b/src/app/(landing)/blog/page.tsx
@@ -34,6 +34,7 @@ export default function Index() {
           src="/Ebowwa-5-25-2024 (1).png"
           alt="Header Image"
           fill
+          sizes="100vw"
           style={{
             objectPosition: 'center',
           }}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -60,6 +60,7 @@ const ImageCarousel = ({
         src={images[0].url}
         alt={images[0].alt}
         fill
+        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
         className="object-cover transition-transform duration-300 group-hover:scale-105"
       />
     );
@@ -78,6 +79,7 @@ const ImageCarousel = ({
               src={image.url}
               alt={image.alt}
               fill
+              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
               className="object-cover"
               priority={index === 0}
             />

--- a/src/components/landing/sections/blog/components/cover-image.tsx
+++ b/src/components/landing/sections/blog/components/cover-image.tsx
@@ -1,6 +1,7 @@
 "use client"
 import cn from "classnames";
 import Link from "next/link";
+import Image from "next/image";
 import { z } from 'zod';
 import { route } from "@/lib/constants";
 import { useState } from "react";
@@ -30,10 +31,13 @@ const CoverImage = ({ title, githubPath, slug }: Props) => {
   const imageUrl = `${baseURL}/${githubPath}`;
 
   const image = (
-    <img
+    <Image
       src={imageUrl}
       alt={`Cover Image for ${title}`}
-      className={cn("shadow-sm w-full", {
+      width={1600}
+      height={900}
+      sizes="(max-width: 640px) 100vw, 640px"
+      className={cn("shadow-sm w-full h-auto", {
         "hover:shadow-lg transition-shadow duration-200": slug,
       })}
       onLoad={() => setIsLoading(false)}

--- a/src/components/landing/sections/general/SuccessfulCampaigns.tsx
+++ b/src/components/landing/sections/general/SuccessfulCampaigns.tsx
@@ -1,6 +1,7 @@
 // SuccessfulCampaigns.tsx
 import React from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 export interface Bot {
     bot: string;
     idea: string;
@@ -46,12 +47,13 @@ const SuccessfulCampaigns: React.FC<SuccessfulCampaignsProps> = ({ title, descri
                                         <h3 className="text-2xl font-bold">{bot.bot}</h3>
                                         <p className="text-lg">{bot.idea}</p>
                                     </div>
-                                    <img
+                                    <Image
                                         alt={`Portfolio ${index + 1}`}
-                                        className="mb-4 aspect-[4/3] w-full rounded-lg object-cover h-[300px]"
-                                        height="300"
+                                        className="mb-4 aspect-[4/3] w-full rounded-lg object-cover"
                                         src={bot.image}
-                                        width="400"
+                                        width={400}
+                                        height={300}
+                                        sizes="(max-width: 640px) 100vw, 400px"
                                     />
                                 </div>
                             </Link>

--- a/src/components/landing/sections/general/promotional/WorldMap/world_background_map.tsx
+++ b/src/components/landing/sections/general/promotional/WorldMap/world_background_map.tsx
@@ -1,20 +1,21 @@
 // src/components/landing/sections/general/world_background_map.tsx
 import Link from "next/link";
+import Image from "next/image";
 import data from "@public/raw_data/world_background_map.json";
 
 export default function HomePage() {
   return (
     <div className="relative w-full h-[400px] lg:h-[500px] overflow-hidden rounded-lg">
-      <img
+      <Image
         alt="World Map"
-        className="absolute inset-0 w-full h-full object-cover opacity-20"
-        height={1080}
         src="/placeholder.svg"
+        fill
+        sizes="100vw"
+        className="absolute inset-0 object-cover opacity-20"
         style={{
           aspectRatio: "1920/1080",
           objectFit: "cover",
         }}
-        width={1920}
       />
       <div className="absolute inset-0 flex justify-between items-center bg-white/70 px-4 py-6 shadow-md rounded-lg overflow-hidden">
         <div className="flex flex-col items-center justify-center">


### PR DESCRIPTION
## Summary
- make hero blog image responsive
- add sizes to homepage carousel images
- make cover images and promotional images mobile friendly
- tweak screenshot and conversion pages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f677c63a0832fbf49f66712c167e8