### PR TITLE
Add internationalization

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,22 @@
+{
+  "appName": "Ebowwa",
+  "appDescription": "Structured interfaces between humans, machines, and meaning. Built with care. Meant to last.",
+  "homeTitle": "Ebowwa Labs",
+  "homeSubtitle": "Structured interfaces between humans, machines, and meaning. Built with care. Meant to last.",
+  "sleepLoopsTitle": "Sleep Loops",
+  "sleepLoopsDescription": "Transform your sleep environment with curated ambient loops. Focus, relax, or drift off.",
+  "sleepLoopsLinkText": "Download on the App Store",
+  "developersTitle": "Developers",
+  "developersDescription": "Explore a collection of developer-focused tools and utilities.",
+  "developersLinkText": "Explore Catalog",
+  "thinkersTitle": "Thinkers & Learners",
+  "thinkersDescription": "Dive into the concept of the informational substrate and expand your understanding of our digital reality.",
+  "appEnthusiastsTitle": "App Enthusiasts",
+  "appEnthusiastsDescription": "Discover and try our unique mobile apps designed to improve your life, creativity, and productivity.",
+  "appEnthusiastsLinkText": "See All Apps",
+  "employersTitle": "Employers & Collaborators",
+  "employersDescription": "Learn more about my skills and past projects. Let's create something amazing together.",
+  "employersLinkText": "View Resume",
+  "closingStatement": "This lab showcases proven execution and a forward-thinking vision, creating opportunities for collaboration, investment, and impactful projects.",
+  "footerCopyright": "{year} Ebowwa Labs • Pushing the boundaries of what's possible"
+}

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,0 +1,22 @@
+{
+  "appName": "Ebowwa",
+  "appDescription": "Interfaces estructuradas entre humanos, máquinas y significado. Construido con esmero. Hecho para durar.",
+  "homeTitle": "Ebowwa Labs",
+  "homeSubtitle": "Interfaces estructuradas entre humanos, máquinas y significado. Construido con esmero. Hecho para durar.",
+  "sleepLoopsTitle": "Bucles de Sueño",
+  "sleepLoopsDescription": "Transforma tu entorno de sueño con bucles ambientales seleccionados. Concéntrate, relájate o duerme.",
+  "sleepLoopsLinkText": "Descargar en la App Store",
+  "developersTitle": "Desarrolladores",
+  "developersDescription": "Explora una colección de herramientas y utilidades para desarrolladores.",
+  "developersLinkText": "Explorar Catálogo",
+  "thinkersTitle": "Pensadores y Estudiosos",
+  "thinkersDescription": "Sumérgete en el concepto del sustrato informacional y amplía tu comprensión de nuestra realidad digital.",
+  "appEnthusiastsTitle": "Entusiastas de Apps",
+  "appEnthusiastsDescription": "Descubre y prueba nuestras apps móviles únicas diseñadas para mejorar tu vida, creatividad y productividad.",
+  "appEnthusiastsLinkText": "Ver Todas las Apps",
+  "employersTitle": "Empleadores y Colaboradores",
+  "employersDescription": "Conoce más sobre mis habilidades y proyectos pasados. Creamos algo increíble juntos.",
+  "employersLinkText": "Ver Curriculum",
+  "closingStatement": "Este laboratorio muestra una ejecución probada y una visión de futuro, creando oportunidades de colaboración, inversión y proyectos impactantes.",
+  "footerCopyright": "{year} Ebowwa Labs • Impulsando los límites de lo posible"
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,7 @@
 import createMiddleware from 'next-intl/middleware'
 
 export default createMiddleware({
-  locales: ['en'],
+  locales: ['en', 'es'],
   defaultLocale: 'en'
 })
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,20 +2,26 @@
 import { Layout } from '@/components/landing/layout/dom/Layout';
 import Head from '../components/landing/layout/head';
 import '@/styles/global.css';
-import { Analytics } from "@vercel/analytics/react"
-import translations from './en.json';
+import { Analytics } from '@vercel/analytics/react';
+import {NextIntlClientProvider} from 'next-intl';
+import {getLocale, getMessages} from 'next-intl/server';
 
-export const metadata = {
-  title: translations.appName.value,
-  description: translations.appDescription.value,
-};
+export async function generateMetadata() {
+  const messages = await getMessages();
+  return {
+    title: messages.appName as string,
+    description: messages.appDescription as string
+  };
+}
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
   // Register the Serwist service worker
   registerWebWorker('/public/serwist.worker.ts');
+  const locale = await getLocale();
+  const messages = await getMessages();
 
   return (
-    <html lang="en" className="antialiased">
+    <html lang={locale} className="antialiased">
       {/*
         <head /> will contain the components returned by the nearest parent
         head.tsx. Find out more at https://beta.nextjs.org/docs/api-reference/file-conventions/head
@@ -23,8 +29,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <Head />
       <body>
         {/* To avoid FOUT with styled-components wrap Layout with StyledComponentsRegistry https://beta.nextjs.org/docs/styling/css-in-js#styled-components */}
-        <Layout>{children}</Layout>
-        <Analytics />
+        <NextIntlClientProvider messages={messages} locale={locale}>
+          <Layout>{children}</Layout>
+          <Analytics />
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import translations from './en.json';
+import {useTranslations} from 'next-intl';
 import { DevelopersImages, AppEnthusiastsImages, ThinkersImages, EmployersImages } from '@/utils/AssetCatalog';
 
 // Card type definition for better type safety
@@ -285,14 +285,7 @@ const FeatureCard = ({
 export default function HomePage() {
   // Flag to control link visibility
   const showLinks = true; // Set to false to hide links temporarily
-  const {
-    homeTitle, homeSubtitle,
-    developersTitle, developersDescription, developersLinkText,
-    thinkersTitle, thinkersDescription,
-    appEnthusiastsTitle, appEnthusiastsDescription, appEnthusiastsLinkText,
-    employersTitle, employersDescription, employersLinkText,
-    closingStatement
-  } = translations;
+  const t = useTranslations();
 
   return (
     <div className="min-h-screen relative overflow-hidden bg-gradient-to-br from-black via-gray-900 to-blue-900 text-white">
@@ -316,11 +309,11 @@ export default function HomePage() {
         <div className="text-center mb-10 sm:mb-16">
           <h1 className="text-5xl sm:text-6xl md:text-7xl font-extrabold mb-3 relative">
             <span className="bg-clip-text text-transparent bg-gradient-to-r from-emerald-400 to-cyan-400 animate-pulse">
-              {homeTitle.value}
+              {t('homeTitle')}
             </span>
           </h1>
           <p className="text-lg sm:text-xl text-blue-200 leading-relaxed px-4 sm:px-0">
-            {homeSubtitle.value}
+            {t('homeSubtitle')}
           </p>
           <p className="text-sm sm:text-base text-blue-200/60 max-w-xl mx-auto mt-2 sm:mt-3 leading-loose font-light italic px-4 sm:px-0">
             Focused on practical, resilient software engineering—creating mobile-first and offline-capable systems that deliver real value.
@@ -332,19 +325,19 @@ export default function HomePage() {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 md:gap-8 w-full max-w-7xl mx-auto">
           {/* Using the new FeatureCard component */}
           <FeatureCard
-            title={developersTitle.value}
-            description={developersDescription.value}
+            title={t('developersTitle')}
+            description={t('developersDescription')}
             icon="⚙️"
             color="cyan"
             linkUrl="/catalog"
-            linkText={developersLinkText.value}
+            linkText={t('developersLinkText')}
             showLinks={showLinks}
             images={DevelopersImages}
           />
           
           <FeatureCard
-            title={thinkersTitle.value}
-            description={thinkersDescription.value}
+            title={t('thinkersTitle')}
+            description={t('thinkersDescription')}
             icon="🧠"
             color="emerald"
             disabled={true}
@@ -354,23 +347,23 @@ export default function HomePage() {
           {/*i want to be able to have this showing previews of multiple of my apps, currently it only shows sleep loops but i have other apps and images to include */}
 
           <FeatureCard
-            title={appEnthusiastsTitle.value}
-            description={appEnthusiastsDescription.value}
+            title={t('appEnthusiastsTitle')}
+            description={t('appEnthusiastsDescription')}
             icon="📱"
             color="purple"
             linkUrl="/apps"
-            linkText={appEnthusiastsLinkText.value}
+            linkText={t('appEnthusiastsLinkText')}
             showLinks={showLinks}
             images={AppEnthusiastsImages}
           />
           
           <FeatureCard
-            title={employersTitle.value}
-            description={employersDescription.value}
+            title={t('employersTitle')}
+            description={t('employersDescription')}
             icon="🚀"
             color="red"
             linkUrl="/elijah/whoiselijah"
-            linkText={employersLinkText.value}
+            linkText={t('employersLinkText')}
             showLinks={showLinks}
             images={EmployersImages}
           />
@@ -393,7 +386,7 @@ export default function HomePage() {
         {/* Closing Statement */}
         <div className="mt-8 sm:mt-12 mb-6 sm:mb-8 max-w-3xl mx-auto text-center">
           <p className="text-lg sm:text-xl text-blue-200 leading-relaxed px-3 sm:px-6">
-            {closingStatement.value}
+            {t('closingStatement')}
           </p>
         </div>
       

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,0 +1,4 @@
+export type Locale = (typeof locales)[number];
+
+export const locales = ['en', 'es'] as const;
+export const defaultLocale: Locale = 'en';


### PR DESCRIPTION
## Summary
- provide i18n messages for English and Spanish
- set up next-intl middleware
- use NextIntl in layout and home page

## Testing
- `pnpm install --ignore-scripts --frozen-lockfile`
- `pnpm lint` *(fails: ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_683f707f41e8832fad52a7f2b727a73e