### PR TITLE
Remove empty images placeholder

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -23,7 +23,6 @@ const nextConfig = {
   // compiler: {
   //   styledComponents: true,
   // },  
-  images: {},
   webpack: (config, { isServer }) => {
     if (!isServer) {
       // Don't resolve 'tls' module on the client-side


### PR DESCRIPTION
## Summary
- clean up `next.config.js` by removing an unused empty `images` setting

## Testing
- `pnpm install`
- `pnpm lint` *(fails: Cannot read config file)*

------
https://chatgpt.com/codex/tasks/task_e_683f9049c838832f805e7b6152935032