### PR TITLE
Add label for apps home link

### DIFF
--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -49,6 +49,7 @@ export default function AppsPage() {
             <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
             </svg>
+            <span>{t('backToHome')}</span>
           </Link>
         </div>
         


### PR DESCRIPTION
## Summary
- show translated "backToHome" label next to the back arrow in apps page

## Testing
- `pnpm install` *(fails to run lint due to invalid ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_683f902c6a0c832f9ba6ef250409c7d4