### PR TITLE
Fix duplicate metadata declaration

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,15 +16,6 @@ export async function generateMetadata() {
   };
 }
 
-
-export async function generateMetadata() {
-  const messages = await getMessages();
-  return {
-    title: messages.appName as string,
-    description: messages.appDescription as string
-  };
-}
-
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   // Register the Serwist service worker
   registerWebWorker('/public/serwist.worker.ts');


### PR DESCRIPTION
## Summary
- clean up `src/app/layout.tsx` so there's only a single `generateMetadata` function

## Testing
- `pnpm lint` *(fails: Cannot read config file)*

------
https://chatgpt.com/codex/tasks/task_e_683f9484cac8832fad9de8d98161db36