### PR TITLE
Add shared chat feature

### DIFF
--- a/src/app/chat-shares/[slug]/page.tsx
+++ b/src/app/chat-shares/[slug]/page.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getChatShare, getAllChatShareSlugs } from '../../../data/chatShares';
+
+export async function generateStaticParams() {
+  const slugs = getAllChatShareSlugs();
+  return slugs.map(slug => ({ slug }));
+}
+
+export async function generateMetadata({ params }: { params: { slug: string } }) {
+  const chat = getChatShare(params.slug);
+  if (!chat) {
+    return {
+      title: 'Chat Not Found',
+      description: 'The requested chat could not be found',
+    };
+  }
+  return {
+    title: chat.title,
+    description: chat.title,
+  };
+}
+
+export default function ChatSharePage({ params }: { params: { slug: string } }) {
+  const chat = getChatShare(params.slug);
+  if (!chat) {
+    notFound();
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <Link href="/chat-shares" className="text-blue-500 underline">Back</Link>
+      <h1 className="text-3xl font-bold my-4">{chat.title}</h1>
+      <p className="text-sm text-gray-500 mb-4">{chat.date}</p>
+      {chat.url ? (
+        <a href={chat.url} target="_blank" rel="noopener noreferrer" className="text-blue-500 underline">
+          View conversation on ChatGPT
+        </a>
+      ) : (
+        <div className="prose" dangerouslySetInnerHTML={{ __html: chat.content }} />
+      )}
+    </div>
+  );
+}
+

--- a/src/app/chat-shares/page.tsx
+++ b/src/app/chat-shares/page.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import Link from 'next/link';
+import { getAllChatShares } from '../../data/chatShares';
+
+export const metadata = {
+  title: 'Shared Chats',
+  description: 'Collection of shared ChatGPT conversations',
+};
+
+export default function ChatSharesPage() {
+  const chats = getAllChatShares();
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-6">
+      <h1 className="text-3xl font-bold">Shared Chats</h1>
+      {chats.map(chat => (
+        <div key={chat.slug} className="border-b pb-4">
+          <h2 className="text-xl font-semibold">
+            <Link href={`/chat-shares/${chat.slug}`}>{chat.title}</Link>
+          </h2>
+          <p className="text-sm text-gray-500">{chat.date}</p>
+          {chat.url && (
+            <a
+              href={chat.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-500 underline"
+            >
+              View on ChatGPT
+            </a>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/src/data/chatShares.ts
+++ b/src/data/chatShares.ts
@@ -1,0 +1,15 @@
+import { ChatShare } from './types';
+import chatSharesData from './chatShares/data';
+
+export function getAllChatShares(): ChatShare[] {
+  return chatSharesData;
+}
+
+export function getChatShare(slug: string): ChatShare | undefined {
+  return chatSharesData.find(chat => chat.slug === slug);
+}
+
+export function getAllChatShareSlugs(): string[] {
+  return chatSharesData.map(chat => chat.slug);
+}
+

--- a/src/data/chatShares/data.ts
+++ b/src/data/chatShares/data.ts
@@ -1,0 +1,22 @@
+import { ChatShare } from '../types';
+
+const chatShares: ChatShare[] = [
+  {
+    slug: 'ai-meeting-summary',
+    title: 'AI Meeting Summary',
+    date: 'May 30, 2025',
+    url: 'https://chat.openai.com/share/xyz123',
+    content: ''
+  },
+  {
+    slug: 'design-brainstorm-notes',
+    title: 'Design Brainstorm Notes',
+    date: 'June 2, 2025',
+    content: `
+      <p>This conversation covers design ideas for upcoming projects and does not have a public share URL.</p>
+    `
+  }
+];
+
+export default chatShares;
+

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -11,3 +11,11 @@ export interface Link {
   tags?: string[];
   related?: string[];
 }
+
+export interface ChatShare {
+  slug: string;
+  title: string;
+  date: string;
+  url?: string;
+  content: string;
+}


### PR DESCRIPTION
## Summary
- add `ChatShare` interface and dataset
- add page to list shared chats
- add dynamic page to view individual chats

## Testing
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_683fe606db2c832fa5d07d4afe1d8d5f