### PR TITLE
Improve chat share UI

### DIFF
--- a/src/app/chat-shares/[slug]/page.tsx
+++ b/src/app/chat-shares/[slug]/page.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/landing/ui/card'
+import { getChatShare, getAllChatShareSlugs } from '../../../data/chatShares'
+
+export async function generateStaticParams() {
+  const slugs = getAllChatShareSlugs();
+  return slugs.map(slug => ({ slug }));
+}
+
+export async function generateMetadata({ params }: { params: { slug: string } }) {
+  const chat = getChatShare(params.slug);
+  if (!chat) {
+    return {
+      title: 'Chat Not Found',
+      description: 'The requested chat could not be found',
+    };
+  }
+  return {
+    title: chat.title,
+    description: chat.title,
+  };
+}
+
+export default function ChatSharePage({ params }: { params: { slug: string } }) {
+  const chat = getChatShare(params.slug);
+  if (!chat) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-black via-gray-900 to-blue-900 text-white py-16 px-6">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <Link href="/chat-shares" className="text-teal-400 hover:underline">&larr; Back</Link>
+        <Card className="bg-white/10 border border-white/20 backdrop-blur">
+          <CardHeader>
+            <CardTitle className="text-teal-300 text-3xl font-bold mb-2">{chat.title}</CardTitle>
+            <p className="text-sm text-blue-200">{chat.date}</p>
+          </CardHeader>
+          <CardContent>
+            {chat.url ? (
+              <a href={chat.url} target="_blank" rel="noopener noreferrer" className="text-teal-400 hover:underline">
+                View conversation on ChatGPT
+              </a>
+            ) : (
+              <div className="prose prose-invert" dangerouslySetInnerHTML={{ __html: chat.content }} />
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/chat-shares/page.tsx
+++ b/src/app/chat-shares/page.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import Link from 'next/link'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/landing/ui/card'
+import { getAllChatShares } from '../../data/chatShares'
+
+export const metadata = {
+  title: 'Shared Chats',
+  description: 'Collection of shared ChatGPT conversations',
+};
+
+export default function ChatSharesPage() {
+  const chats = getAllChatShares()
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-black via-gray-900 to-blue-900 text-white py-16 px-6">
+      <div className="max-w-4xl mx-auto space-y-8">
+        <h1 className="text-center text-4xl font-extrabold mb-6">Shared Chats</h1>
+        <div className="grid gap-6">
+          {chats.map((chat) => (
+            <Card
+              key={chat.slug}
+              className="bg-white/10 border border-white/20 backdrop-blur hover:border-teal-500/50 transition-all"
+            >
+              <CardHeader>
+                <CardTitle>
+                  <Link href={`/chat-shares/${chat.slug}`} className="hover:underline text-teal-300">
+                    {chat.title}
+                  </Link>
+                </CardTitle>
+                <p className="text-sm text-blue-200">{chat.date}</p>
+              </CardHeader>
+              {chat.url && (
+                <CardContent>
+                  <a
+                    href={chat.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-teal-400 hover:underline"
+                  >
+                    View on ChatGPT
+                  </a>
+                </CardContent>
+              )}
+            </Card>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/src/data/chatShares.ts
+++ b/src/data/chatShares.ts
@@ -1,0 +1,15 @@
+import { ChatShare } from './types';
+import chatSharesData from './chatShares/data';
+
+export function getAllChatShares(): ChatShare[] {
+  return chatSharesData;
+}
+
+export function getChatShare(slug: string): ChatShare | undefined {
+  return chatSharesData.find(chat => chat.slug === slug);
+}
+
+export function getAllChatShareSlugs(): string[] {
+  return chatSharesData.map(chat => chat.slug);
+}
+

--- a/src/data/chatShares/data.ts
+++ b/src/data/chatShares/data.ts
@@ -1,0 +1,22 @@
+import { ChatShare } from '../types';
+
+const chatShares: ChatShare[] = [
+  {
+    slug: 'ai-meeting-summary',
+    title: 'AI Meeting Summary',
+    date: 'May 30, 2025',
+    url: 'https://chat.openai.com/share/xyz123',
+    content: ''
+  },
+  {
+    slug: 'design-brainstorm-notes',
+    title: 'Design Brainstorm Notes',
+    date: 'June 2, 2025',
+    content: `
+      <p>This conversation covers design ideas for upcoming projects and does not have a public share URL.</p>
+    `
+  }
+];
+
+export default chatShares;
+

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -11,3 +11,11 @@ export interface Link {
   tags?: string[];
   related?: string[];
 }
+
+export interface ChatShare {
+  slug: string;
+  title: string;
+  date: string;
+  url?: string;
+  content: string;
+}


### PR DESCRIPTION
## Summary
- use gradient background and Card components for `chat-shares` list
- style individual shared chat page with cards and dark gradient background

## Testing
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_683fe606db2c832fa5d07d4afe1d8d5f