### PR TITLE
Add link preview scraping

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "antd": "^5.17.0",
     "base64-arraybuffer": "^1.0.2",
     "bittorrent-dht": "^11.0.5",
+    "cheerio": "^1.0.0",
     "class-variance-authority": "^0.7.0",
     "classnames": "^2.5.1",
     "clipboard-copy": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       bittorrent-dht:
         specifier: ^11.0.5
         version: 11.0.5
+      cheerio:
+        specifier: ^1.0.0
+        version: 1.0.0
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -2945,6 +2948,9 @@ packages:
   block-iterator@1.1.1:
     resolution: {integrity: sha512-DrjdVWZemVO4iBf4tiOXjUrY5cNesjzy0t7sIiu2rdl8cOCHRxAgKjSJFc3vBZYYMMmshUAxajl8QQh/uxXTKQ==}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
@@ -3059,6 +3065,13 @@ packages:
 
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.0.0:
+    resolution: {integrity: sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==}
+    engines: {node: '>=18.17'}
 
   chevrotain@10.5.0:
     resolution: {integrity: sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==}
@@ -3240,12 +3253,19 @@ packages:
   css-line-break@2.1.0:
     resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
+  css-select@5.1.0:
+    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
+
   css-to-react-native@3.2.0:
     resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
   css-tree@2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-what@6.1.0:
+    resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
+    engines: {node: '>= 6'}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -3498,6 +3518,9 @@ packages:
 
   encode-utf8@1.0.3:
     resolution: {integrity: sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==}
+
+  encoding-sniffer@0.2.0:
+    resolution: {integrity: sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==}
 
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
@@ -5102,6 +5125,9 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
   nwsapi@2.2.9:
     resolution: {integrity: sha512-2f3F0SEEer8bBu0dsNCFF50N0cTThV1nWFYcEYFZttdW0lDAoybv9cQoK7X7/68Z89S7FoRrVjP1LPX4XRf9vg==}
 
@@ -5233,6 +5259,12 @@ packages:
     resolution: {integrity: sha512-5GoOdmW0HpiB78aQpBz8/5V3V1LjBRDNiL7DOs33pKeCLOzFnfMrsRD6CYmaUBT5Vi/dXE0hfePsjDGJSMF48w==}
     engines: {node: '>=12.20.0'}
     hasBin: true
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
 
   parse5@7.1.2:
     resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
@@ -6664,6 +6696,10 @@ packages:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
     engines: {node: '>=14.0'}
 
+  undici@6.21.3:
+    resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
+    engines: {node: '>=18.17'}
+
   unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
     engines: {node: '>=4'}
@@ -6933,9 +6969,17 @@ packages:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   whatwg-url@12.0.1:
     resolution: {integrity: sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==}
@@ -10231,6 +10275,8 @@ snapshots:
 
   block-iterator@1.1.1: {}
 
+  boolbase@1.0.0: {}
+
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -10344,6 +10390,29 @@ snapshots:
   character-entities-legacy@3.0.0: {}
 
   character-entities@2.0.2: {}
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.1.0
+      css-what: 6.1.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+
+  cheerio@1.0.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      encoding-sniffer: 0.2.0
+      htmlparser2: 9.1.0
+      parse5: 7.1.2
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 6.21.3
+      whatwg-mimetype: 4.0.0
 
   chevrotain@10.5.0:
     dependencies:
@@ -10543,6 +10612,14 @@ snapshots:
     dependencies:
       utrie: 1.0.2
 
+  css-select@5.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.1.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      nth-check: 2.1.1
+
   css-to-react-native@3.2.0:
     dependencies:
       camelize: 1.0.1
@@ -10553,6 +10630,8 @@ snapshots:
     dependencies:
       mdn-data: 2.0.30
       source-map-js: 1.2.0
+
+  css-what@6.1.0: {}
 
   cssesc@3.0.0: {}
 
@@ -10788,6 +10867,11 @@ snapshots:
 
   encode-utf8@1.0.3: {}
 
+  encoding-sniffer@0.2.0:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
   end-of-stream@1.4.4:
     dependencies:
       once: 1.4.0
@@ -10919,7 +11003,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -10946,8 +11030,8 @@ snapshots:
       debug: 4.3.4
       enhanced-resolve: 5.16.1
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.13.1
@@ -10958,7 +11042,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -10969,7 +11053,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -10979,7 +11063,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -11765,7 +11849,6 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
-    optional: true
 
   idb@6.1.5: {}
 
@@ -12731,6 +12814,10 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
   nwsapi@2.2.9:
     optional: true
 
@@ -12878,6 +12965,15 @@ snapshots:
       magnet-uri: 7.0.5
       queue-microtask: 1.2.3
       uint8-util: 2.2.5
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.1.2
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.1.2
 
   parse5@7.1.2:
     dependencies:
@@ -13797,8 +13893,7 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.1.4
 
-  safer-buffer@2.1.2:
-    optional: true
+  safer-buffer@2.1.2: {}
 
   sax@1.3.0: {}
 
@@ -14540,6 +14635,8 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.1
 
+  undici@6.21.3: {}
+
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -14886,8 +14983,14 @@ snapshots:
       iconv-lite: 0.6.3
     optional: true
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
   whatwg-mimetype@3.0.0:
     optional: true
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-url@12.0.1:
     dependencies:

--- a/src/app/api/link-preview/route.ts
+++ b/src/app/api/link-preview/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest } from 'next/server'
+import * as cheerio from 'cheerio'
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const targetUrl = searchParams.get('url')
+  if (!targetUrl) {
+    return new Response('Missing URL', { status: 400 })
+  }
+  if (targetUrl.includes('localhost') || targetUrl.includes('127.0.0.1')) {
+    return new Response('Invalid target', { status: 400 })
+  }
+  try {
+    const html = await fetch(targetUrl).then(r => r.text())
+    const $ = cheerio.load(html)
+
+    const getMeta = (name: string) =>
+      $(`meta[property='${name}']`).attr('content') ||
+      $(`meta[name='${name}']`).attr('content')
+
+    const base = new URL(targetUrl)
+    const favicon = $('link[rel="icon"]').attr('href') || '/favicon.ico'
+
+    return Response.json({
+      title: getMeta('og:title') || $('title').text(),
+      description: getMeta('og:description') || getMeta('description'),
+      image: getMeta('og:image'),
+      favicon: favicon.startsWith('/') ? `${base.origin}${favicon}` : favicon,
+    })
+  } catch (e) {
+    console.error('Preview error', e)
+    return new Response('Failed to fetch metadata', { status: 500 })
+  }
+}

--- a/src/app/chat-shares/[slug]/page.tsx
+++ b/src/app/chat-shares/[slug]/page.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/landing/ui/card'
+import { getChatShare, getAllChatShareSlugs } from '../../../data/chatShares'
+
+export async function generateStaticParams() {
+  const slugs = getAllChatShareSlugs();
+  return slugs.map(slug => ({ slug }));
+}
+
+export async function generateMetadata({ params }: { params: { slug: string } }) {
+  const chat = getChatShare(params.slug);
+  if (!chat) {
+    return {
+      title: 'Chat Not Found',
+      description: 'The requested chat could not be found',
+    };
+  }
+  return {
+    title: chat.title,
+    description: chat.title,
+  };
+}
+
+export default function ChatSharePage({ params }: { params: { slug: string } }) {
+  const chat = getChatShare(params.slug);
+  if (!chat) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-black via-gray-900 to-blue-900 text-white py-16 px-6">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <Link href="/chat-shares" className="text-teal-400 hover:underline">&larr; Back</Link>
+        <Card className="bg-white/10 border border-white/20 backdrop-blur">
+          <CardHeader>
+            <CardTitle className="text-teal-300 text-3xl font-bold mb-2">{chat.title}</CardTitle>
+            <p className="text-sm text-blue-200">{chat.date}</p>
+          </CardHeader>
+          <CardContent>
+            {chat.url ? (
+              <a href={chat.url} target="_blank" rel="noopener noreferrer" className="text-teal-400 hover:underline">
+                View conversation on ChatGPT
+              </a>
+            ) : (
+              <div className="prose prose-invert" dangerouslySetInnerHTML={{ __html: chat.content }} />
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/chat-shares/page.tsx
+++ b/src/app/chat-shares/page.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import Link from 'next/link'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/landing/ui/card'
+import { getAllChatShares } from '../../data/chatShares'
+
+export const metadata = {
+  title: 'Shared Chats',
+  description: 'Collection of shared ChatGPT conversations',
+};
+
+export default function ChatSharesPage() {
+  const chats = getAllChatShares()
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-black via-gray-900 to-blue-900 text-white py-16 px-6">
+      <div className="max-w-4xl mx-auto space-y-8">
+        <h1 className="text-center text-4xl font-extrabold mb-6">Shared Chats</h1>
+        <div className="grid gap-6">
+          {chats.map((chat) => (
+            <Card
+              key={chat.slug}
+              className="bg-white/10 border border-white/20 backdrop-blur hover:border-teal-500/50 transition-all"
+            >
+              <CardHeader>
+                <CardTitle>
+                  <Link href={`/chat-shares/${chat.slug}`} className="hover:underline text-teal-300">
+                    {chat.title}
+                  </Link>
+                </CardTitle>
+                <p className="text-sm text-blue-200">{chat.date}</p>
+              </CardHeader>
+              {chat.url && (
+                <CardContent>
+                  <a
+                    href={chat.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-teal-400 hover:underline"
+                  >
+                    View on ChatGPT
+                  </a>
+                </CardContent>
+              )}
+            </Card>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/src/app/link-preview/page.tsx
+++ b/src/app/link-preview/page.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import LinkPreview from '@/components/LinkPreview'
+
+export const metadata = {
+  title: 'Link Preview Demo',
+  description: 'Paste a URL to see its metadata',
+}
+
+export default function LinkPreviewPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-black via-gray-900 to-blue-900 text-white py-16 px-6">
+      <div className="max-w-xl mx-auto space-y-8">
+        <h1 className="text-center text-4xl font-extrabold">Link Preview</h1>
+        <LinkPreview />
+      </div>
+    </div>
+  )
+}

--- a/src/components/LinkPreview.tsx
+++ b/src/components/LinkPreview.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react'
+
+export default function LinkPreview() {
+  const [url, setUrl] = useState('')
+  const [preview, setPreview] = useState<any>(null)
+  const [loading, setLoading] = useState(false)
+
+  const fetchPreview = async () => {
+    if (!url) return
+    setLoading(true)
+    setPreview(null)
+    try {
+      const res = await fetch(`/api/link-preview?url=${encodeURIComponent(url)}`)
+      if (res.ok) {
+        const data = await res.json()
+        setPreview(data)
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={url}
+          onChange={e => setUrl(e.target.value)}
+          placeholder="Paste URL here"
+          className="flex-1 px-3 py-2 rounded bg-white/10 border border-white/20 text-white placeholder-gray-400 focus:outline-none"
+        />
+        <button
+          onClick={fetchPreview}
+          className="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-500"
+        >
+          Preview
+        </button>
+      </div>
+      {loading && <p className="text-blue-200">Loading...</p>}
+      {preview && (
+        <div className="bg-white/10 border border-white/20 rounded p-4 space-y-2">
+          {(preview.image || preview.favicon) && (
+            <img
+              src={preview.image || preview.favicon}
+              alt="preview"
+              className="w-16 h-16 object-contain"
+            />
+          )}
+          <h3 className="text-xl font-bold">{preview.title}</h3>
+          <p className="text-blue-100">{preview.description}</p>
+          <a
+            href={url}
+            target="_blank"
+            rel="noreferrer"
+            className="text-teal-400 hover:underline"
+          >
+            Visit
+          </a>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/data/chatShares.ts
+++ b/src/data/chatShares.ts
@@ -1,0 +1,15 @@
+import { ChatShare } from './types';
+import chatSharesData from './chatShares/data';
+
+export function getAllChatShares(): ChatShare[] {
+  return chatSharesData;
+}
+
+export function getChatShare(slug: string): ChatShare | undefined {
+  return chatSharesData.find(chat => chat.slug === slug);
+}
+
+export function getAllChatShareSlugs(): string[] {
+  return chatSharesData.map(chat => chat.slug);
+}
+

--- a/src/data/chatShares/data.ts
+++ b/src/data/chatShares/data.ts
@@ -1,0 +1,22 @@
+import { ChatShare } from '../types';
+
+const chatShares: ChatShare[] = [
+  {
+    slug: 'ai-meeting-summary',
+    title: 'AI Meeting Summary',
+    date: 'May 30, 2025',
+    url: 'https://chat.openai.com/share/xyz123',
+    content: ''
+  },
+  {
+    slug: 'design-brainstorm-notes',
+    title: 'Design Brainstorm Notes',
+    date: 'June 2, 2025',
+    content: `
+      <p>This conversation covers design ideas for upcoming projects and does not have a public share URL.</p>
+    `
+  }
+];
+
+export default chatShares;
+

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -11,3 +11,11 @@ export interface Link {
   tags?: string[];
   related?: string[];
 }
+
+export interface ChatShare {
+  slug: string;
+  title: string;
+  date: string;
+  url?: string;
+  content: string;
+}


### PR DESCRIPTION
## Summary
- add `cheerio` dependency for scraping metadata
- create `/api/link-preview` for server-side scraping
- add `LinkPreview` component and demo page

## Testing
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm lint` *(fails: interactive ESLint prompt)*

------
https://chatgpt.com/codex/tasks/task_e_683fe606db2c832fa5d07d4afe1d8d5f