### PR TITLE
Polyfill ProgressEvent for server build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,4 @@
+require('./progress-event-polyfill');
 // next.config.mjs
 /** @type {import('next').NextConfig} */
 const withBundleAnalyzer = require('@next/bundle-analyzer')({

--- a/progress-event-polyfill.js
+++ b/progress-event-polyfill.js
@@ -1,0 +1,10 @@
+if (typeof globalThis.ProgressEvent === 'undefined') {
+  globalThis.ProgressEvent = class ProgressEvent {
+    constructor(type, options = {}) {
+      this.type = type;
+      this.lengthComputable = !!options.lengthComputable;
+      this.loaded = options.loaded || 0;
+      this.total = options.total || 0;
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add a ProgressEvent polyfill for server builds
- require the polyfill in `next.config.js` so Node has a definition

## Testing
- `node -r ./progress-event-polyfill.js -e "console.log(typeof ProgressEvent)"`
- `npm run build` *(fails to show full output in this environment, but reaches "Compiled successfully" without ProgressEvent errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846322aaf7c832fb8ba640a90558eef