### PR TITLE
Add Player GLTF type export

### DIFF
--- a/src/components/three/assets/mario/Player.tsx
+++ b/src/components/three/assets/mario/Player.tsx
@@ -5,7 +5,7 @@ import { useGLTF, useAnimations } from '@react-three/drei';
 import { useGSAP } from '@gsap/react';
 import gsap from 'gsap';
 import { Group, SkinnedMesh} from 'three';
-import { GLTFResult } from '../../studio/src/core/ModelLoader';
+import { GLTFResult } from './PlayerTyped';
 
 
 // Define the props interface for the Player component

--- a/src/components/three/assets/mario/PlayerTyped.tsx
+++ b/src/components/three/assets/mario/PlayerTyped.tsx
@@ -1,0 +1,10 @@
+import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
+
+export type GLTFResult = GLTF & {
+  nodes: {
+    [key: string]: any
+  }
+  materials: {
+    [key: string]: any
+  }
+}


### PR DESCRIPTION
## Summary
- export `GLTFResult` in `PlayerTyped.tsx`
- update Player to import the type from new file

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488d5a8314832fbb408c79b3baa2fd