### PR TITLE
Update PrintPeer card link

### DIFF
--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -261,7 +261,12 @@ export default function AppsPage() {
                 Community platform for sharing and discovering printable art and designs.
               </p>
               <div className="flex flex-wrap items-center gap-4">
-                <span className="text-xs uppercase tracking-wider text-teal-200/60">Coming Soon</span>
+                <a href="https://printpeer.xyz" target="_blank" rel="noopener noreferrer" className="inline-flex items-center px-4 py-2 bg-teal-500/20 border border-teal-500/50 rounded-lg text-teal-300 hover:bg-teal-500/30 transition-all group-hover:pl-6">
+                  <span>Visit Early Preview</span>
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 ml-2 group-hover:ml-3 transition-all" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                  </svg>
+                </a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- update PrintPeer card on Apps page to link to the early preview

## Testing
- `pnpm lint` *(fails: next not found because node_modules are missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f883d4330832fa8f93cf61cfe5b1e