### PR TITLE
Add Discord invite links

### DIFF
--- a/src/app/(landing)/landing/layout.tsx
+++ b/src/app/(landing)/landing/layout.tsx
@@ -11,6 +11,7 @@ const navbarLinks = [
   { label: 'Catalog', href: '/catalog' },
   { label: 'Simulation', href: '/simulation' },
   { label: 'Contact', href: '/contact' },
+  { label: 'Discord', href: 'https://discord.gg/pAsQkT8u' },
 ];
 
 const footerLinks = [
@@ -21,6 +22,7 @@ const footerLinks = [
 
 const socialMedia = [
   { platform: 'Twitter', url: 'https://twitter.com/Simulation_API' },
+  { platform: 'Discord', url: 'https://discord.gg/pAsQkT8u' },
 ];
 
 const copyright = ' 2024 SimulationAPI. All rights reserved.';

--- a/src/components/landing/sections/general/General_Landing_Container.tsx
+++ b/src/components/landing/sections/general/General_Landing_Container.tsx
@@ -36,12 +36,20 @@ export default function LandingContainer() {
                     <h1 className="text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl">{textData.welcomeTitle}</h1>
                     <p className="max-w-xl text-lg">{textData.welcomeDescription}</p>
                     <div className="flex items-center space-x-8">
-                        <div>
+                        <div className="flex space-x-4">
                             <Link
                                 className="inline-flex h-10 items-center justify-center rounded-md bg-white px-6 py-2 text-sm font-medium text-gray-900 transition-colors hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900"
                                 href="#"
                             >
                                 {textData.learnMoreLabel}
+                            </Link>
+                            <Link
+                                className="inline-flex h-10 items-center justify-center rounded-md bg-indigo-600 px-6 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900"
+                                href="https://discord.gg/pAsQkT8u"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Join our Discord
                             </Link>
                         </div>
                         <div className="w-64 h-64" suppressHydrationWarning>


### PR DESCRIPTION
## Summary
- add a prominent Discord button on the landing page
- include Discord link in navigation and footer

## Testing
- `npx prettier -c "./src/**/*.{ts,tsx,md}" "./app/**/*.{ts,tsx,md}"`
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f93142c38832f83d055a07d866e05