### PR TITLE
Add Discord invite banner

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import Head from '../components/landing/layout/head';
 import '@/styles/global.css';
 import { Analytics } from "@vercel/analytics/react"
 import translations from './en.json';
+import DiscordInviteBanner from '@/components/DiscordInviteBanner';
 
 export const metadata = {
   title: translations.appName.value,
@@ -35,6 +36,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body>
         {/* To avoid FOUT with styled-components wrap Layout with StyledComponentsRegistry https://beta.nextjs.org/docs/styling/css-in-js#styled-components */}
         <Layout>{children}</Layout>
+        <DiscordInviteBanner />
         <Analytics />
       </body>
     </html>

--- a/src/components/DiscordInviteBanner.tsx
+++ b/src/components/DiscordInviteBanner.tsx
@@ -1,0 +1,16 @@
+'use client'
+import { usePathname } from 'next/navigation'
+import Link from 'next/link'
+
+export default function DiscordInviteBanner() {
+  const pathname = usePathname()
+  if (pathname.startsWith('/landing')) return null
+  return (
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 bg-indigo-600 text-white px-4 py-2 rounded-lg shadow-lg flex items-center gap-2">
+      <span>Join our community on Discord!</span>
+      <Link href="https://discord.gg/pAsQkT8u" target="_blank" rel="noopener noreferrer" className="underline font-semibold">
+        Click here
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- include Discord banner to encourage joining the community
- show it on all pages except those under `/landing`

## Testing
- `pnpm install`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_685f95e14f08832faa6b91ba04610f37