### PR TITLE
Update references from Simulation Guide to Ebowwa Labs

### DIFF
--- a/public/html/sitemap.json
+++ b/public/html/sitemap.json
@@ -9,7 +9,7 @@
     ]
 },
     {
-      "title": "Simulation Guide [preview]",
+      "title": "Ebowwa Labs",
       "links": [
         {
           "label": "Landing",

--- a/src/app/(landing)/landing/layout.tsx
+++ b/src/app/(landing)/landing/layout.tsx
@@ -20,10 +20,10 @@ const footerLinks = [
 ];
 
 const socialMedia = [
-  { platform: 'Twitter', url: 'https://twitter.com/Simulation_API' },
+  { platform: 'Twitter', url: 'https://twitter.com/innitEbowwa' },
 ];
 
-const copyright = ' 2024 SimulationAPI. All rights reserved.';
+const copyright = ' 2024 Ebowwa Labs. All rights reserved.';
 
 export default function RootLayout({
   children,
@@ -34,7 +34,7 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <Navbar
-          logo={{ altText: 'SimulationAPI' }}
+          logo={{ altText: 'Ebowwa Labs' }}
           links={navbarLinks}
         />
         <Layout>

--- a/src/components/landing/layout/head.tsx
+++ b/src/components/landing/layout/head.tsx
@@ -1,5 +1,5 @@
 // app/head.tsx
-const title = 'Simulation Guide'
+const title = 'Ebowwa Labs'
 const url = 'https://ebowwa.xyz/'
 const description = 'Building fast and with precision. Ebowwa Labs runs multiple projects exploring offline, AI-first solutions. We cut through fluff to deliver actionable systems that remove friction and accelerate growth.'
 const author = 'Elijah Arbee'

--- a/src/components/utility/sharing/QR/ui.tsx
+++ b/src/components/utility/sharing/QR/ui.tsx
@@ -11,7 +11,7 @@ import QRCodeGenerator from './QRCodeGenerator';
 import marketplaceContent from '@public/html/marketplaceContent.json';
 import Image from 'next/image';
 
-const QR_CODE_LINK = 'https://simulationguide.vercel.app/';
+const QR_CODE_LINK = 'https://ebowwa.xyz/';
 
 const ShareButton: FC = () => {
     return (


### PR DESCRIPTION
## Summary
- rename site title to **Ebowwa Labs**
- update sitemap entry from "Simulation Guide" to **Ebowwa Labs**
- update QR code link to point at `https://ebowwa.xyz/`
- tweak landing layout text to show **Ebowwa Labs**

## Testing
- `pnpm install`
- `pnpm lint` *(fails: interactive configuration)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685fa9a070b0832f94ced87101331f95