### PR TITLE
Fix Discord banner overlap

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         head.tsx. Find out more at https://beta.nextjs.org/docs/api-reference/file-conventions/head
       */}
       <Head />
-      <body>
+      <body className="pb-28">
         {/* To avoid FOUT with styled-components wrap Layout with StyledComponentsRegistry https://beta.nextjs.org/docs/styling/css-in-js#styled-components */}
         <Layout>{children}</Layout>
         <DiscordInviteBanner />


### PR DESCRIPTION
## Summary
- ensure the body has bottom padding so the Discord banner doesn't cover the footer

## Testing
- `pnpm lint` *(fails: `next lint` interactive setup)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6864d77424cc832fb860b7b0bb210f97